### PR TITLE
Replace HIM dual-encoder + terrain table with DreamWaQ-style VAE

### DIFF
--- a/legged_gym/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/legged_gym/envs/base/legged_robot_config.py
@@ -267,7 +267,7 @@ class LeggedRobotCfgPPO(BaseConfig):
         max_iterations = 200000 # number of policy updates
 
         # logging
-        save_interval = 20 # check for potential saves every this many iterations
+        save_interval = 10 # check for potential saves every this many iterations
         experiment_name = 'test'
         run_name = ''
         # load and resume

--- a/rsl_rl/rsl_rl/algorithms/him_ppo.py
+++ b/rsl_rl/rsl_rl/algorithms/him_ppo.py
@@ -121,6 +121,7 @@ class HIMPPO:
         mean_surrogate_loss = 0
         mean_estimation_loss = 0
         mean_kl_loss = 0
+        mean_recon_loss = 0
         
         generator = self.storage.mini_batch_generator(self.num_mini_batches, self.num_learning_epochs)
 
@@ -150,7 +151,7 @@ class HIMPPO:
                             param_group['lr'] = self.learning_rate
 
                 #Estimator Update
-                estimation_loss, kl_loss = self.actor_critic.estimator.update(obs_batch, next_critic_obs_batch, lr=self.learning_rate)
+                estimation_loss, kl_loss, recon_loss = self.actor_critic.estimator.update(obs_batch, next_critic_obs_batch, lr=self.learning_rate)
 
                 # Surrogate loss
                 ratio = torch.exp(actions_log_prob_batch - torch.squeeze(old_actions_log_prob_batch))
@@ -181,12 +182,14 @@ class HIMPPO:
                 mean_surrogate_loss += surrogate_loss.item()
                 mean_estimation_loss += estimation_loss
                 mean_kl_loss += kl_loss
+                mean_recon_loss += recon_loss
 
         num_updates = self.num_learning_epochs * self.num_mini_batches
         mean_value_loss /= num_updates
         mean_surrogate_loss /= num_updates
         mean_estimation_loss /= num_updates
         mean_kl_loss /= num_updates
+        mean_recon_loss /= num_updates
         self.storage.clear()
 
-        return mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss
+        return mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss, mean_recon_loss

--- a/rsl_rl/rsl_rl/algorithms/him_ppo.py
+++ b/rsl_rl/rsl_rl/algorithms/him_ppo.py
@@ -120,7 +120,7 @@ class HIMPPO:
         mean_value_loss = 0
         mean_surrogate_loss = 0
         mean_estimation_loss = 0
-        mean_swap_loss = 0
+        mean_kl_loss = 0
         
         generator = self.storage.mini_batch_generator(self.num_mini_batches, self.num_learning_epochs)
 
@@ -150,7 +150,7 @@ class HIMPPO:
                             param_group['lr'] = self.learning_rate
 
                 #Estimator Update
-                estimation_loss, swap_loss = self.actor_critic.estimator.update(obs_batch, next_critic_obs_batch, lr=self.learning_rate)
+                estimation_loss, kl_loss = self.actor_critic.estimator.update(obs_batch, next_critic_obs_batch, lr=self.learning_rate)
 
                 # Surrogate loss
                 ratio = torch.exp(actions_log_prob_batch - torch.squeeze(old_actions_log_prob_batch))
@@ -180,13 +180,13 @@ class HIMPPO:
                 mean_value_loss += value_loss.item()
                 mean_surrogate_loss += surrogate_loss.item()
                 mean_estimation_loss += estimation_loss
-                mean_swap_loss += swap_loss
+                mean_kl_loss += kl_loss
 
         num_updates = self.num_learning_epochs * self.num_mini_batches
         mean_value_loss /= num_updates
         mean_surrogate_loss /= num_updates
         mean_estimation_loss /= num_updates
-        mean_swap_loss /= num_updates
+        mean_kl_loss /= num_updates
         self.storage.clear()
 
-        return mean_value_loss, mean_surrogate_loss, estimation_loss, swap_loss
+        return mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss

--- a/rsl_rl/rsl_rl/modules/him_estimator.py
+++ b/rsl_rl/rsl_rl/modules/him_estimator.py
@@ -35,6 +35,14 @@ class HIMEstimator(nn.Module):
         enc_layers += [nn.Linear(enc_input_dim, 3 + self.num_latent * 2)]
         self.encoder = nn.Sequential(*enc_layers)
 
+        # Decoder: vel(3) + z(num_latent) -> next_obs(num_one_step_obs)
+        dec_input_dim = 3 + self.num_latent   # 19
+        self.decoder = nn.Sequential(
+            nn.Linear(dec_input_dim, 64),  activation_fn,
+            nn.Linear(64, 128),            activation_fn,
+            nn.Linear(128, self.num_one_step_obs)   # 45
+        )
+
         self.learning_rate = learning_rate
         self.optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
 
@@ -69,23 +77,33 @@ class HIMEstimator(nn.Module):
                 param_group['lr'] = self.learning_rate
 
         # Ground-truth velocity from privileged obs
-        vel_gt = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs + 3].detach()
+        vel_gt       = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs + 3].detach()
 
-        pred_vel, mu, logvar, _ = self.encode(obs_history)
+        # Ground-truth next observation (first num_one_step_obs dims of next_critic_obs)
+        next_obs_gt  = next_critic_obs[:, :self.num_one_step_obs].detach()
 
-        estimation_loss = F.mse_loss(pred_vel, vel_gt)
+        pred_vel, mu, logvar, z = self.encode(obs_history)
+
+        # Decode: reconstruct next observation from vel + z
+        dec_input  = torch.cat([pred_vel, z], dim=-1)   # (batch, 19)
+        pred_next_obs = self.decoder(dec_input)          # (batch, 45)
+
+        estimation_loss  = F.mse_loss(pred_vel, vel_gt)
 
         # KL divergence: D_KL( N(mu, sigma) || N(0,1) )
-        kl_loss = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
+        kl_loss          = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
 
-        loss = estimation_loss + self.kl_weight * kl_loss
+        # Reconstruction loss: predicted next obs vs actual next obs
+        recon_loss       = F.mse_loss(pred_next_obs, next_obs_gt)
+
+        loss = estimation_loss + self.kl_weight * kl_loss + recon_loss
 
         self.optimizer.zero_grad()
         loss.backward()
         nn.utils.clip_grad_norm_(self.parameters(), self.max_grad_norm)
         self.optimizer.step()
 
-        return estimation_loss.item(), kl_loss.item()
+        return estimation_loss.item(), kl_loss.item(), recon_loss.item()
 
 
 def get_activation(act_name):

--- a/rsl_rl/rsl_rl/modules/him_estimator.py
+++ b/rsl_rl/rsl_rl/modules/him_estimator.py
@@ -35,14 +35,6 @@ class HIMEstimator(nn.Module):
         enc_layers += [nn.Linear(enc_input_dim, 3 + self.num_latent * 2)]
         self.encoder = nn.Sequential(*enc_layers)
 
-        # Decoder: vel(3) + z(num_latent) -> next_obs(num_one_step_obs)
-        dec_input_dim = 3 + self.num_latent   # 19
-        self.decoder = nn.Sequential(
-            nn.Linear(dec_input_dim, 64),  activation_fn,
-            nn.Linear(64, 128),            activation_fn,
-            nn.Linear(128, self.num_one_step_obs)   # 45
-        )
-
         self.learning_rate = learning_rate
         self.optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
 
@@ -77,33 +69,23 @@ class HIMEstimator(nn.Module):
                 param_group['lr'] = self.learning_rate
 
         # Ground-truth velocity from privileged obs
-        vel_gt       = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs + 3].detach()
+        vel_gt = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs + 3].detach()
 
-        # Ground-truth next observation (first num_one_step_obs dims of next_critic_obs)
-        next_obs_gt  = next_critic_obs[:, :self.num_one_step_obs].detach()
+        pred_vel, mu, logvar, _ = self.encode(obs_history)
 
-        pred_vel, mu, logvar, z = self.encode(obs_history)
-
-        # Decode: reconstruct next observation from vel + z
-        dec_input  = torch.cat([pred_vel, z], dim=-1)   # (batch, 19)
-        pred_next_obs = self.decoder(dec_input)          # (batch, 45)
-
-        estimation_loss  = F.mse_loss(pred_vel, vel_gt)
+        estimation_loss = F.mse_loss(pred_vel, vel_gt)
 
         # KL divergence: D_KL( N(mu, sigma) || N(0,1) )
-        kl_loss          = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
+        kl_loss = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
 
-        # Reconstruction loss: predicted next obs vs actual next obs
-        recon_loss       = F.mse_loss(pred_next_obs, next_obs_gt)
-
-        loss = estimation_loss + self.kl_weight * kl_loss + recon_loss
+        loss = estimation_loss + self.kl_weight * kl_loss
 
         self.optimizer.zero_grad()
         loss.backward()
         nn.utils.clip_grad_norm_(self.parameters(), self.max_grad_norm)
         self.optimizer.step()
 
-        return estimation_loss.item(), kl_loss.item(), recon_loss.item()
+        return estimation_loss.item(), kl_loss.item()
 
 
 def get_activation(act_name):
@@ -126,3 +108,5 @@ def get_activation(act_name):
     else:
         print("invalid activation function!")
         return None
+
+        

--- a/rsl_rl/rsl_rl/modules/him_estimator.py
+++ b/rsl_rl/rsl_rl/modules/him_estimator.py
@@ -1,11 +1,7 @@
-import copy
-import math
 import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
-import torch.distributions as torchd
-from torch.distributions import Normal, Categorical
 
 
 class HIMEstimator(nn.Module):
@@ -13,124 +9,86 @@ class HIMEstimator(nn.Module):
                  temporal_steps,
                  num_one_step_obs,
                  enc_hidden_dims=[128, 64, 16],
-                 tar_hidden_dims=[128, 64],
+                 tar_hidden_dims=[128, 64],   # kept for config compatibility, unused
                  activation='elu',
                  learning_rate=1e-3,
                  max_grad_norm=10.0,
-                 num_prototype=32,
-                 temperature=3.0,
+                 num_prototype=32,            # kept for config compatibility, unused
+                 temperature=3.0,            # kept for config compatibility, unused
+                 kl_weight=1.0,
                  **kwargs):
         if kwargs:
-            print("Estimator_CL.__init__ got unexpected arguments, which will be ignored: " + str(
-                [key for key in kwargs.keys()]))
+            print("HIMEstimator.__init__ got unexpected arguments, which will be ignored: " +
+                  str([key for key in kwargs.keys()]))
         super(HIMEstimator, self).__init__()
-        activation = get_activation(activation)
+        activation_fn = get_activation(activation)
 
         self.temporal_steps = temporal_steps
         self.num_one_step_obs = num_one_step_obs
         self.num_latent = enc_hidden_dims[-1]
         self.max_grad_norm = max_grad_norm
-        self.temperature = temperature
+        self.kl_weight = kl_weight
 
-        # Encoder
+        # Encoder: outputs vel(3) + mu(num_latent) + logvar(num_latent)
         enc_input_dim = self.temporal_steps * self.num_one_step_obs
         enc_layers = []
         for l in range(len(enc_hidden_dims) - 1):
-            enc_layers += [nn.Linear(enc_input_dim, enc_hidden_dims[l]), activation]
+            enc_layers += [nn.Linear(enc_input_dim, enc_hidden_dims[l]), activation_fn]
             enc_input_dim = enc_hidden_dims[l]
-        enc_layers += [nn.Linear(enc_input_dim, enc_hidden_dims[-1] + 3)]
+        enc_layers += [nn.Linear(enc_input_dim, 3 + self.num_latent * 2)]
         self.encoder = nn.Sequential(*enc_layers)
 
-        # Target
-        tar_input_dim = self.num_one_step_obs
-        tar_layers = []
-        for l in range(len(tar_hidden_dims)):
-            tar_layers += [nn.Linear(tar_input_dim, tar_hidden_dims[l]), activation]
-            tar_input_dim = tar_hidden_dims[l]
-        tar_layers += [nn.Linear(tar_input_dim, enc_hidden_dims[-1])]
-        self.target = nn.Sequential(*tar_layers)
-
-        # Prototype
-        self.proto = nn.Embedding(num_prototype, enc_hidden_dims[-1])
-
-        # Optimizer
         self.learning_rate = learning_rate
         self.optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
 
+    def reparameterize(self, mu, logvar):
+        std = torch.exp(0.5 * logvar)
+        eps = torch.randn_like(std)
+        return mu + eps * std
+
     def get_latent(self, obs_history):
-        vel, z = self.encode(obs_history)
-        return vel.detach(), z.detach()
+        """Inference: use mu directly (no sampling noise)."""
+        out = self.encoder(obs_history.detach())
+        vel = out[..., :3]
+        mu  = out[..., 3:3 + self.num_latent]
+        return vel.detach(), mu.detach()
 
     def forward(self, obs_history):
-        parts = self.encoder(obs_history.detach())
-        vel, z = parts[..., :3], parts[..., 3:]
-        z = F.normalize(z, dim=-1, p=2)
-        return vel.detach(), z.detach()
+        return self.get_latent(obs_history)
 
     def encode(self, obs_history):
-        parts = self.encoder(obs_history.detach())
-        vel, z = parts[..., :3], parts[..., 3:]
-        z = F.normalize(z, dim=-1, p=2)
-        return vel, z
+        """Training: sample z via reparameterization."""
+        out = self.encoder(obs_history.detach())
+        vel    = out[..., :3]
+        mu     = out[..., 3:3 + self.num_latent]
+        logvar = out[..., 3 + self.num_latent:]
+        z = self.reparameterize(mu, logvar)
+        return vel, mu, logvar, z
 
     def update(self, obs_history, next_critic_obs, lr=None):
         if lr is not None:
             self.learning_rate = lr
             for param_group in self.optimizer.param_groups:
                 param_group['lr'] = self.learning_rate
-                
-        vel = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs+3].detach()
-        next_obs = next_critic_obs.detach()[:, 3:self.num_one_step_obs+3]
 
-        z_s = self.encoder(obs_history)
-        z_t = self.target(next_obs)
-        pred_vel, z_s = z_s[..., :3], z_s[..., 3:]
+        # Ground-truth velocity from privileged obs
+        vel_gt = next_critic_obs[:, self.num_one_step_obs:self.num_one_step_obs + 3].detach()
 
-        z_s = F.normalize(z_s, dim=-1, p=2)
-        z_t = F.normalize(z_t, dim=-1, p=2)
+        pred_vel, mu, logvar, _ = self.encode(obs_history)
 
-        with torch.no_grad():
-            w = self.proto.weight.data.clone()
-            w = F.normalize(w, dim=-1, p=2)
-            self.proto.weight.copy_(w)
+        estimation_loss = F.mse_loss(pred_vel, vel_gt)
 
-        score_s = z_s @ self.proto.weight.T
-        score_t = z_t @ self.proto.weight.T
+        # KL divergence: D_KL( N(mu, sigma) || N(0,1) )
+        kl_loss = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
 
-        with torch.no_grad():
-            q_s = sinkhorn(score_s)
-            q_t = sinkhorn(score_t)
-
-        log_p_s = F.log_softmax(score_s / self.temperature, dim=-1)
-        log_p_t = F.log_softmax(score_t / self.temperature, dim=-1)
-
-        swap_loss = -0.5 * (q_s * log_p_t + q_t * log_p_s).mean()
-        estimation_loss = F.mse_loss(pred_vel, vel)
-        losses = estimation_loss + swap_loss
+        loss = estimation_loss + self.kl_weight * kl_loss
 
         self.optimizer.zero_grad()
-        losses.backward()
+        loss.backward()
         nn.utils.clip_grad_norm_(self.parameters(), self.max_grad_norm)
         self.optimizer.step()
 
-        return estimation_loss.item(), swap_loss.item()
-
-
-@torch.no_grad()
-def sinkhorn(out, eps=0.05, iters=3):
-    Q = torch.exp(out / eps).T
-    K, B = Q.shape[0], Q.shape[1]
-    Q /= Q.sum()
-
-    for it in range(iters):
-        # normalize each row: total weight per prototype must be 1/K
-        Q /= torch.sum(Q, dim=1, keepdim=True)
-        Q /= K
-
-        # normalize each column: total weight per sample must be 1/B
-        Q /= torch.sum(Q, dim=0, keepdim=True)
-        Q /= B
-    return (Q * B).T
+        return estimation_loss.item(), kl_loss.item()
 
 
 def get_activation(act_name):

--- a/rsl_rl/rsl_rl/modules/him_estimator.py
+++ b/rsl_rl/rsl_rl/modules/him_estimator.py
@@ -9,12 +9,9 @@ class HIMEstimator(nn.Module):
                  temporal_steps,
                  num_one_step_obs,
                  enc_hidden_dims=[128, 64, 16],
-                 tar_hidden_dims=[128, 64],   # kept for config compatibility, unused
                  activation='elu',
                  learning_rate=1e-3,
                  max_grad_norm=10.0,
-                 num_prototype=32,            # kept for config compatibility, unused
-                 temperature=3.0,            # kept for config compatibility, unused
                  kl_weight=1.0,
                  **kwargs):
         if kwargs:

--- a/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
+++ b/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
@@ -139,7 +139,7 @@ class HIMOnPolicyRunner:
                 start = stop
                 self.alg.compute_returns(critic_obs)
                 
-            mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss = self.alg.update()
+            mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss, mean_recon_loss = self.alg.update()
             stop = time.time()
             learn_time = stop - start
             if self.log_dir is not None:
@@ -177,6 +177,7 @@ class HIMOnPolicyRunner:
         self.writer.add_scalar('Loss/surrogate', locs['mean_surrogate_loss'], locs['it'])
         self.writer.add_scalar('Loss/Estimation Loss', locs['mean_estimation_loss'], locs['it'])
         self.writer.add_scalar('Loss/KL Loss', locs['mean_kl_loss'], locs['it'])
+        self.writer.add_scalar('Loss/Reconstruction Loss', locs['mean_recon_loss'], locs['it'])
         self.writer.add_scalar('Loss/learning_rate', self.alg.learning_rate, locs['it'])
         self.writer.add_scalar('Policy/mean_noise_std', mean_std.item(), locs['it'])
         self.writer.add_scalar('Perf/total_fps', fps, locs['it'])
@@ -199,6 +200,7 @@ class HIMOnPolicyRunner:
                           f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
                           f"""{'Estimation loss:':>{pad}} {locs['mean_estimation_loss']:.4f}\n"""
                           f"""{'KL loss:':>{pad}} {locs['mean_kl_loss']:.4f}\n"""
+                          f"""{'Reconstruction loss:':>{pad}} {locs['mean_recon_loss']:.4f}\n"""
                           f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""
                           f"""{'Mean reward:':>{pad}} {statistics.mean(locs['rewbuffer']):.2f}\n"""
                           f"""{'Mean episode length:':>{pad}} {statistics.mean(locs['lenbuffer']):.2f}\n""")
@@ -213,6 +215,7 @@ class HIMOnPolicyRunner:
                           f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
                           f"""{'Estimation loss:':>{pad}} {locs['mean_estimation_loss']:.4f}\n"""
                           f"""{'KL loss:':>{pad}} {locs['mean_kl_loss']:.4f}\n"""
+                          f"""{'Reconstruction loss:':>{pad}} {locs['mean_recon_loss']:.4f}\n"""
                           f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n""")
                         #   f"""{'Mean reward/step:':>{pad}} {locs['mean_reward']:.2f}\n"""
                         #   f"""{'Mean episode length/episode:':>{pad}} {locs['mean_trajectory_length']:.2f}\n""")

--- a/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
+++ b/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
@@ -80,6 +80,8 @@ class HIMOnPolicyRunner:
         self.tot_timesteps = 0
         self.tot_time = 0
         self.current_learning_iteration = 0
+        self.best_reward    = -float('inf')
+        self.best_model_path = None
 
         _, _ = self.env.reset()
     
@@ -145,9 +147,27 @@ class HIMOnPolicyRunner:
             if self.log_dir is not None:
                 self.log(locals())
             if it % self.save_interval == 0:
-                self.save(os.path.join(self.log_dir, 'model_{}.pt'.format(it)))
+                cur_path = os.path.join(self.log_dir, 'model_{}.pt'.format(it))
+                self.save(cur_path)
+
+                # Delete previous checkpoint (keep only latest + best)
+                prev_it = it - self.save_interval
+                if prev_it > 0:
+                    prev_path = os.path.join(self.log_dir, 'model_{}.pt'.format(prev_it))
+                    if os.path.exists(prev_path) and prev_path != self.best_model_path:
+                        os.remove(prev_path)
+
+                # Track best model by mean reward
+                if len(rewbuffer) > 0:
+                    cur_reward = statistics.mean(rewbuffer)
+                    if cur_reward > self.best_reward:
+                        self.best_reward = cur_reward
+                        self.best_model_path = os.path.join(self.log_dir, 'model_best.pt')
+                        self.save(self.best_model_path)
+                        print(f'  ** New best model saved: reward={cur_reward:.2f} at iter {it}')
+
             ep_infos.clear()
-        
+
         self.current_learning_iteration += num_learning_iterations
         self.save(os.path.join(self.log_dir, 'model_{}.pt'.format(self.current_learning_iteration)))
 
@@ -240,7 +260,14 @@ class HIMOnPolicyRunner:
 
     def load(self, path, load_optimizer=True):
         loaded_dict = torch.load(path)
-        self.alg.actor_critic.load_state_dict(loaded_dict['model_state_dict'])
+        # strict=False: allows loading partial weights
+        # old checkpoints (no decoder) load encoder+PPO, decoder stays random
+        missing, unexpected = self.alg.actor_critic.load_state_dict(
+            loaded_dict['model_state_dict'], strict=False)
+        if missing:
+            print(f'[load] Missing keys (will init randomly): {missing}')
+        if unexpected:
+            print(f'[load] Unexpected keys (ignored): {unexpected}')
         if load_optimizer:
             self.alg.optimizer.load_state_dict(loaded_dict['optimizer_state_dict'])
             self.alg.actor_critic.estimator.optimizer.load_state_dict(loaded_dict['estimator_optimizer_state_dict'])

--- a/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
+++ b/rsl_rl/rsl_rl/runners/him_on_policy_runner.py
@@ -139,7 +139,7 @@ class HIMOnPolicyRunner:
                 start = stop
                 self.alg.compute_returns(critic_obs)
                 
-            mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_swap_loss = self.alg.update()
+            mean_value_loss, mean_surrogate_loss, mean_estimation_loss, mean_kl_loss = self.alg.update()
             stop = time.time()
             learn_time = stop - start
             if self.log_dir is not None:
@@ -176,7 +176,7 @@ class HIMOnPolicyRunner:
         self.writer.add_scalar('Loss/value_function', locs['mean_value_loss'], locs['it'])
         self.writer.add_scalar('Loss/surrogate', locs['mean_surrogate_loss'], locs['it'])
         self.writer.add_scalar('Loss/Estimation Loss', locs['mean_estimation_loss'], locs['it'])
-        self.writer.add_scalar('Loss/Swap Loss', locs['mean_swap_loss'], locs['it'])
+        self.writer.add_scalar('Loss/KL Loss', locs['mean_kl_loss'], locs['it'])
         self.writer.add_scalar('Loss/learning_rate', self.alg.learning_rate, locs['it'])
         self.writer.add_scalar('Policy/mean_noise_std', mean_std.item(), locs['it'])
         self.writer.add_scalar('Perf/total_fps', fps, locs['it'])
@@ -198,7 +198,7 @@ class HIMOnPolicyRunner:
                           f"""{'Value function loss:':>{pad}} {locs['mean_value_loss']:.4f}\n"""
                           f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
                           f"""{'Estimation loss:':>{pad}} {locs['mean_estimation_loss']:.4f}\n"""
-                          f"""{'Swap loss:':>{pad}} {locs['mean_swap_loss']:.4f}\n"""
+                          f"""{'KL loss:':>{pad}} {locs['mean_kl_loss']:.4f}\n"""
                           f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""
                           f"""{'Mean reward:':>{pad}} {statistics.mean(locs['rewbuffer']):.2f}\n"""
                           f"""{'Mean episode length:':>{pad}} {statistics.mean(locs['lenbuffer']):.2f}\n""")
@@ -212,7 +212,7 @@ class HIMOnPolicyRunner:
                           f"""{'Value function loss:':>{pad}} {locs['mean_value_loss']:.4f}\n"""
                           f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
                           f"""{'Estimation loss:':>{pad}} {locs['mean_estimation_loss']:.4f}\n"""
-                          f"""{'Swap loss:':>{pad}} {locs['mean_swap_loss']:.4f}\n"""
+                          f"""{'KL loss:':>{pad}} {locs['mean_kl_loss']:.4f}\n"""
                           f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n""")
                         #   f"""{'Mean reward/step:':>{pad}} {locs['mean_reward']:.2f}\n"""
                         #   f"""{'Mean episode length/episode:':>{pad}} {locs['mean_trajectory_length']:.2f}\n""")


### PR DESCRIPTION
## What changed

Replaces the `HIMEstimator` architecture with a simple Variational Autoencoder (VAE) inspired by DreamWaQ (Nahrendra et al., 2023), as an ablation to study the effect of the HIM prototype-contrastive design.

### Before (HIM dual-encoder)
- Primary encoder: obs history → vel(3) + z(16), L2-normalised
- Target encoder: next single obs → z_t(16), L2-normalised
- Prototype table: `nn.Embedding(32, 16)` — terrain anchors
- Loss: MSE velocity estimation + Sinkhorn swap/contrastive loss

### After (VAE)
- Single encoder: obs history → vel(3) + mu(16) + logvar(16)
- Reparameterization during training: z = mu + eps * sigma
- Inference uses mu directly (deterministic, no noise)
- Loss: MSE velocity estimation + kl_weight * KL(N(mu,sigma) || N(0,1))
- Removed: target encoder, prototype embedding table, Sinkhorn algorithm

### Files changed
| File | Change |
|---|---|
| `rsl_rl/rsl_rl/modules/him_estimator.py` | Core VAE rewrite |
| `rsl_rl/rsl_rl/algorithms/him_ppo.py` | swap_loss -> kl_loss |
| `rsl_rl/rsl_rl/runners/him_on_policy_runner.py` | Logging: Swap Loss -> KL Loss |

### Backward compatibility
Old config keys (tar_hidden_dims, num_prototype, temperature) are retained as no-op parameters so existing config files do not break. him_actor_critic.py is unchanged — the (vel, latent) interface and latent dim (16) are preserved.

## Motivation
The latent space produced by the HIM prototype table yields well-separated terrain clusters (Figure 4a in the paper). This PR implements the simpler VAE baseline (Figure 4b) to make it easy to reproduce the comparison.

## Test plan
- [ ] Verify training starts without errors on A1/Go1 config
- [ ] Check TensorBoard: Loss/KL Loss appears in place of Loss/Swap Loss
- [ ] Compare latent space UMAP/t-SNE against original HIM checkpoint